### PR TITLE
修复了拷贝漫画只显示默认源的Bug

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -119,7 +119,7 @@ android {
 }
 
 greendao {
-    schemaVersion 11
+    schemaVersion 12
 }
 
 dependencies {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -85,6 +85,8 @@
             android:configChanges="orientation|keyboardHidden|screenSize" />
         <activity
             android:name=".ui.activity.StreamReaderActivity"
+            android:forceDarkAllowed="false"
+            android:theme="@style/AppThemeNoDark"
             android:configChanges="orientation|keyboardHidden|screenSize" />
 
         <service android:name=".service.DownloadService" />

--- a/app/src/main/java/com/hiroshi/cimoc/helper/DBOpenHelper.java
+++ b/app/src/main/java/com/hiroshi/cimoc/helper/DBOpenHelper.java
@@ -2,6 +2,7 @@ package com.hiroshi.cimoc.helper;
 
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
+import android.util.Log;
 
 import com.hiroshi.cimoc.model.ChapterDao;
 import com.hiroshi.cimoc.model.ComicDao;
@@ -11,6 +12,7 @@ import com.hiroshi.cimoc.model.SourceDao;
 import com.hiroshi.cimoc.model.TagDao;
 import com.hiroshi.cimoc.model.TagRefDao;
 import com.hiroshi.cimoc.model.TaskDao;
+import com.hiroshi.cimoc.utils.StringUtils;
 
 import org.greenrobot.greendao.database.Database;
 
@@ -34,6 +36,7 @@ public class DBOpenHelper extends DaoMaster.OpenHelper {
 
     @Override
     public void onUpgrade(Database db, int oldVersion, int newVersion) {
+        Log.d("DB", StringUtils.format("DB V:%d,%d", oldVersion, newVersion));
         switch (oldVersion) {
             case 1:
                 SourceDao.createTable(db, false);
@@ -58,7 +61,23 @@ public class DBOpenHelper extends DaoMaster.OpenHelper {
                 updateIntroAndAuthor(db);
                 ChapterDao.createTable(db, true);
                 ImageUrlDao.createTable(db, true);
+            case 11:
+                updateChapter(db);
+
         }
+    }
+
+    private void updateChapter(Database db) {
+        db.beginTransaction();
+        db.execSQL("ALTER TABLE \"CHAPTER\" RENAME TO \"CHAPTER2\"");
+        ChapterDao.createTable(db, false);
+        db.execSQL("INSERT INTO \"CHAPTER\" (\"_id\", \"SOURCE_COMIC\", \"TITLE\", \"PATH\", \"COUNT\", \"COMPLETE\", \"DOWNLOAD\",  \"TID\" , \"SOURCE_GROUP\")" +
+                " SELECT \"_id\", \"SOURCE_COMIC\", \"TITLE\", \"PATH\", \"COUNT\", \"COMPLETE\", \"DOWNLOAD\", \"TID\",\"\" FROM \"CHAPTER2\"");
+        db.execSQL("DROP TABLE \"CHAPTER2\"");
+        db.setTransactionSuccessful();
+        db.endTransaction();
+
+
     }
 
     private void updateLocal(Database db) {

--- a/app/src/main/java/com/hiroshi/cimoc/model/Chapter.java
+++ b/app/src/main/java/com/hiroshi/cimoc/model/Chapter.java
@@ -11,6 +11,7 @@ import org.greenrobot.greendao.annotation.Generated;
 /**
  * Created by Hiroshi on 2016/7/2.
  * fixed by Haleydu on 2020/8/25.
+ * Modified by lx200916 on 2021/2/7
  */
 @Entity
 public class Chapter implements Parcelable {
@@ -36,13 +37,19 @@ public class Chapter implements Parcelable {
     private boolean complete;
     private boolean download;
     private long tid;
+    private String sourceGroup;
 
-    public Chapter(Long id,Long sourceComic,String title, String path, long tid) {
-        this(id,sourceComic,title, path, 0, false, false, tid);
+    public Chapter(Long id, Long sourceComic, String title, String path, long tid) {
+        this(id, sourceComic, title, path, 0, false, false, tid, "");
     }
 
-    public Chapter(Long id,Long sourceComic,String title, String path) {
-        this(id,sourceComic,title, path, 0, false, false, -1);
+    public Chapter(Long id, Long sourceComic, String title, String path, String sourceGroup) {
+        this(id, sourceComic, title, path, 0, false, false, -1, sourceGroup);
+
+    }
+
+    public Chapter(Long id, Long sourceComic, String title, String path) {
+        this(id, sourceComic, title, path, 0, false, false, -1, "");
     }
 
     public Chapter(String title, String path) {
@@ -53,13 +60,18 @@ public class Chapter implements Parcelable {
         this.download = false;
         this.tid = -1;
     }
-    
+
     public Chapter(Parcel source) {
-        this(source.readLong(), source.readLong(),source.readString(), source.readString(), source.readInt(), source.readByte() == 1, source.readByte() == 1, source.readLong());
+        this(source.readLong(), source.readLong(), source.readString(), source.readString(), source.readInt(), source.readByte() == 1, source.readByte() == 1, source.readLong(), "");
     }
 
-    @Generated(hash = 342970835)
-    public Chapter(Long id, @NotNull Long sourceComic, String title, String path, int count, boolean complete, boolean download, long tid) {
+    public Chapter(Long id, Long sourceComic, String title, String path, int progress, boolean b, boolean b1, Long id1) {
+        this(id, sourceComic, title, path, progress, b, b1, id1, "");
+
+    }
+
+    @Generated(hash = 1726293378)
+    public Chapter(Long id, @NotNull Long sourceComic, String title, String path, int count, boolean complete, boolean download, long tid, String sourceGroup) {
         this.id = id;
         this.sourceComic = sourceComic;
         this.title = title;
@@ -68,6 +80,15 @@ public class Chapter implements Parcelable {
         this.complete = complete;
         this.download = download;
         this.tid = tid;
+        this.sourceGroup = sourceGroup;
+    }
+
+    public String getSourceGroup() {
+        return sourceGroup;
+    }
+
+    public void setSourceGroup(String sourceGroup) {
+        this.sourceGroup = sourceGroup;
     }
 
     @Generated(hash = 393170288)

--- a/app/src/main/java/com/hiroshi/cimoc/model/Chapter.java
+++ b/app/src/main/java/com/hiroshi/cimoc/model/Chapter.java
@@ -84,7 +84,7 @@ public class Chapter implements Parcelable {
     }
 
     public String getSourceGroup() {
-        return sourceGroup;
+        return sourceGroup == null ? "" : sourceGroup;
     }
 
     public void setSourceGroup(String sourceGroup) {

--- a/app/src/main/java/com/hiroshi/cimoc/model/Comic.java
+++ b/app/src/main/java/com/hiroshi/cimoc/model/Comic.java
@@ -35,6 +35,8 @@ public class Comic {
     private Integer page;
     private String chapter;
     private String url;
+    @Transient
+    public Object note;
 
 
     private String intro;
@@ -43,7 +45,7 @@ public class Comic {
 
     public Comic(int source, String cid, String title, String cover, String update, String author) {
         this(null, source, cid, title, cover == null ? "" : cover, false, false, update,
-                null, null, null, null, null, null, null, null,null,null);
+                null, null, null, null, null, null, null, null, null, null);
         this.author = author;
     }
 

--- a/app/src/main/java/com/hiroshi/cimoc/ui/adapter/DetailAdapter.java
+++ b/app/src/main/java/com/hiroshi/cimoc/ui/adapter/DetailAdapter.java
@@ -1,9 +1,18 @@
 package com.hiroshi.cimoc.ui.adapter;
 
 import android.content.Context;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
 import android.graphics.Rect;
+
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+
+import android.graphics.Typeface;
+import android.text.TextPaint;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
@@ -39,9 +48,22 @@ public class DetailAdapter extends BaseAdapter<Chapter> {
     private Boolean Reversed = false;
 
     private String last;
+    Paint textPaint;
+
+    Paint paint;
 
     public DetailAdapter(Context context, List<Chapter> list) {
         super(context, list);
+        textPaint = new TextPaint();
+        textPaint.setTypeface(Typeface.DEFAULT_BOLD);
+        textPaint.setFakeBoldText(true);
+        textPaint.setAntiAlias(true);
+        textPaint.setTextSize(40);//文字大小
+        textPaint.setColor(Color.BLACK);//背景颜色
+        textPaint.setTextAlign(Paint.Align.LEFT);
+        paint = new Paint();
+        paint.setColor(ContextCompat.getColor(context, R.color.transparent));
+
     }
 
     @Override
@@ -53,8 +75,45 @@ public class DetailAdapter extends BaseAdapter<Chapter> {
                 if (position == 0) {
                     outRect.set(0, 0, 0, 10);
                 } else {
-                    int offset = parent.getWidth() / 40;
-                    outRect.set(offset, 0, offset, (int) (offset * 1.5));
+                    if (isFirst(position)) {
+                        int offset = parent.getWidth() / 40;
+
+                        outRect.set(offset, 50, offset, (int) (offset * 1.5));
+
+                    } else {
+                        int offset = parent.getWidth() / 40;
+                        outRect.set(offset, 0, offset, (int) (offset * 1.5));
+                    }
+
+
+                }
+            }
+
+            @Override
+            public void onDraw(@NonNull Canvas c, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
+                super.onDraw(c, parent, state);
+                if (parent.getAdapter() != null) {
+                    RecyclerView.Adapter adapter = parent.getAdapter();
+                    int count = parent.getChildCount();
+                    for (int i = 1; i < count; i++) {
+                        View view = parent.getChildAt(i);
+                        int position = parent.getChildLayoutPosition(view);
+                        boolean isHeader = isFirst(position);
+
+                        if (isHeader) {
+                            float top = view.getTop() - 60;
+                            float bottom = view.getTop() - 30;
+                            Rect rect = new Rect(parent.getPaddingLeft(), (int) top, parent.getWidth() - parent.getPaddingRight(), (int) bottom);
+                            c.drawRect(rect, paint);
+                            Paint.FontMetrics fontMetrics = textPaint.getFontMetrics();
+                            float baseline = (rect.bottom + rect.top - fontMetrics.bottom - fontMetrics.top) / 2;
+                            textPaint.setTextAlign(Paint.Align.CENTER);
+                            c.drawText(getGroupName(position), rect.centerX(), baseline, textPaint);
+
+
+                        }  //                            c.drawRect(0, view.getTop() - 1, parent.getWidth(), view.getTop(), mLinePaint);
+
+                    }
                 }
             }
         };
@@ -69,6 +128,22 @@ public class DetailAdapter extends BaseAdapter<Chapter> {
     public void reverse() {
         this.Reversed = !this.Reversed;
         super.reverse();
+    }
+
+    //判断是否分组且当前是否为第一个元素
+    public boolean isFirst(int position) {
+        position = position - 1;
+        if (mDataSet.get(position).getSourceGroup().isEmpty()) return false;
+        if (position == 0) return true;
+        if (position <= 0) {
+            return false;
+        }
+        return !mDataSet.get(position - 1).getSourceGroup().equals(mDataSet.get(position).getSourceGroup());
+    }
+
+    public String getGroupName(int position) {
+        return mDataSet.get(position - 1).getSourceGroup();
+
     }
 
     @Override
@@ -132,7 +207,7 @@ public class DetailAdapter extends BaseAdapter<Chapter> {
                 ChapterHolder viewHolder = (ChapterHolder) holder;
                 viewHolder.chapterButton.setText(chapter.getTitle());
                 viewHolder.chapterButton.setDownload(chapter.isComplete());
-                if (chapter.getPath() !=null &&chapter.getPath().equals(last)) {
+                if (chapter.getPath() != null && chapter.getPath().equals(last)) {
                     viewHolder.chapterButton.setSelected(true);
                 } else if (viewHolder.chapterButton.isSelected()) {
                     viewHolder.chapterButton.setSelected(false);
@@ -151,7 +226,9 @@ public class DetailAdapter extends BaseAdapter<Chapter> {
         manager.setSpanSizeLookup(new GridLayoutManager.SpanSizeLookup() {
             @Override
             public int getSpanSize(int position) {
-                return position == 0 ? manager.getSpanCount() : 1;
+                if (position == 0 || isFirst(position)) return manager.getSpanCount();
+
+                return 1;
             }
         });
     }


### PR DESCRIPTION
（会导致章节界面版式变化，解析时间变长）
*这个提交改变了数据库的表结构*，请检查后再合并
目前由于使用ItemDecoration实现分组名称，每个源第一个章节的按钮会占满屏幕宽度，等待后期优化
![image](https://user-images.githubusercontent.com/44310445/107171852-c1dc9300-69fe-11eb-8a9e-54e4e0d5ba0a.png)
